### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This binding is generated from vk.xml file included in the KhronosRegistry folde
 
 - Vulkan 1.0, 1.1, 1.2, 1.3
 - All Vulkan Extensions as Vulkan RayTracing
-- Raw low level binding using usafe c# code.
+- Raw low level binding using unsafe c# code.
 
 ## Draw Triangle Rasterization
 Test based on https://vulkan-tutorial.com/


### PR DESCRIPTION
"unsafe" instead of "usafe"