### PR TITLE
chore: make workflow branch filters and guards branch-agnostic

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   cd:
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/master'
+    if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
     uses: EvergineTeam/evergine-standards/.github/workflows/binding-xml-cd.yml@v2
     with:
       xml-url: "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/vk.xml"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,9 @@ on:
         type: boolean
         default: false
   push:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
 
 jobs:
   ci:

--- a/.github/workflows/sync-standards.yml
+++ b/.github/workflows/sync-standards.yml
@@ -16,8 +16,8 @@ on:
         default: "v2"
         required: false
       target_branch:
-        description: "Target branch to apply changes"
-        default: "master"
+        description: "Target branch to apply changes (defaults to the repository default branch)"
+        default: ""
         required: false
       script_path:
         description: "Path where to download the sync script"
@@ -41,7 +41,7 @@ on:
   
 jobs:
   sync:
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/master'
+    if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
     permissions:
       contents: write  # allow push commits
       pull-requests: write
@@ -50,7 +50,7 @@ jobs:
       org:  ${{ github.event.inputs.org  || 'EvergineTeam' }}
       repo: ${{ github.event.inputs.repo || 'evergine-standards' }}
       ref:  ${{ github.event.inputs.ref  || 'main' }}
-      target_branch: ${{ github.event.inputs.target_branch || 'master' }}
+      target_branch: ${{ github.event.inputs.target_branch || github.event.repository.default_branch }}
       script_path: ${{ github.event.inputs.script_path || 'sync-standards.ps1' }}
       commit_message: "${{ github.event.inputs.commit_message || vars.STANDARDS_COMMIT_MESSAGE || 'auto: sync standard files [skip ci]' }}"
       mode: ${{ github.event.inputs.mode || 'auto' }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/KhronosGroup/Vulkan-Docs/blob/main/xml/vk.xml.
 ## Draw Triangle Rasterization
 Test based on https://vulkan-tutorial.com/
 
-![alt Draw Triangle Rasterization](https://github.com/EvergineTeam/Vulkan.NET/blob/master/RasterizationTest.png)
+![alt Draw Triangle Rasterization](https://github.com/EvergineTeam/Vulkan.NET/blob/main/RasterizationTest.png)
 
 ## Draw Triangle Raytracing (KHR)
 Test based on https://github.com/maierfelix/VK_KHR_ray_tracing
@@ -25,4 +25,4 @@ Test based on https://github.com/maierfelix/VK_KHR_ray_tracing
  - [NVIDIA Vulkan Beta Driver](https://developer.nvidia.com/vulkan-driver) (Tested with [442.98](https://developer.nvidia.com/vulkan-beta-44298-windows-10))
  - [Vulkan SDK >= 1.2.135.0](https://vulkan.lunarg.com/sdk/home)
 
-![alt Draw Triangle Raytracing](https://github.com/EvergineTeam/Vulkan.NET/blob/master/RaytracingTest.png)
+![alt Draw Triangle Raytracing](https://github.com/EvergineTeam/Vulkan.NET/blob/main/RaytracingTest.png)


### PR DESCRIPTION
Preparación para renombrar la rama por defecto de `master` a `main`.

## Por qué

De los 15 repos de la flota de bindings, 11 ya usan `main`, y tanto las plantillas oficiales (`evergine-standards-template-*`) como el default de `_sync-standards-reusable.yml` asumen `main`. Este repo es una de las 4 excepciones.

Aquí `Sync standards` y `CD` funcionan hoy, pero solo porque alguien acertó a escribir `'master'` a mano en `target_branch`. En los repos hermanos OpenGL.NET y WebGPU.NET ese mismo literal quedó en `'main'` y llevan **4 y 5 meses con el workflow en rojo** sin que nadie se enterase. El literal es la trampa; lo quitamos.

## Qué cambia

- **CI**: los filtros de `push` y `pull_request` aceptan `main` y `master`, para que no haya ninguna ventana sin CI durante el rename.
- **CD y Sync standards**: el guard pasa de `github.ref == 'refs/heads/master'` a `github.ref_name == github.event.repository.default_branch`, que se resuelve en tiempo de ejecución y sobrevive a cualquier rename futuro.
- **Sync standards**: `target_branch` se deriva de la rama por defecto del repo; el input queda con default vacío para que un run manual en blanco también resuelva bien.
- **README**: las dos capturas apuntan a `blob/main`.

## Por qué el guard importa

Si se renombrara la rama sin tocar este `if:`, el cron mensual del CD **se saltaría el job y el run aparecería en verde**: no se publica el NuGet de Vulkan y el badge sigue OK. Ese fallo silencioso es peor que el rojo.

## Después de mergear

1. Renombrar `master` → `main`.
2. Lanzar `Sync standards` y un `CD` con `skip-assets-publishing: true` para confirmar que el job **no** sale como *skipped*.
3. PR de limpieza dejando `branches: [ "main" ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)