### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   cd:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-xml-cd.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-xml-cd.yml@v1
     with:
       xml-url: "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/vk.xml"
       xml-path: "KhronosRegistry/vk.xml"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "VulkanGen/VulkanGen/VulkanGen.csproj"  # Path to your generator .csproj
       generator-name: "Vulkan"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,25 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.Vulkan
+  project: VulkanGen/Evergine.Bindings.Vulkan/Evergine.Bindings.Vulkan.csproj
+  target-framework: net10.0
+  runtime-identifier: ""
+
+upstream:
+  kind: http-file
+  language: c
+  project: https://github.com/KhronosGroup/Vulkan-Docs
+  version-from: spec-attribute      # VK_HEADER_VERSION inside vk.xml
+  sources:
+    - url: https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/vk.xml
+      path: KhronosRegistry/vk.xml
+      format: khronos-xml
+
+generator:
+  project: VulkanGen/VulkanGen/VulkanGen.csproj
+  name: Vulkan
+  output:
+    - VulkanGen/Evergine.Bindings.Vulkan/Generated


### PR DESCRIPTION
Primer repo de la Fase 2. Repunta CI y CD de `evergine-standards@v2` al toolbox `Evergine.Bindings@v1`, y añade el manifiesto `binding.yml`.

## Debe ser un no-op

El toolbox contiene copias **byte-idénticas** de esos reusables. El único cambio aplicado al copiarlos fue repuntar sus `uses:` internos a las acciones del propio toolbox:

| Reusable | Líneas distintas vs `evergine-standards@v2` |
|---|---|
| `binding-common-ci.yml` | 4 (= 2 `uses:` × 2) |
| `binding-xml-cd.yml` | 10 (= 5 `uses:` × 2) |

Las 5 acciones compuestas son byte-idénticas (`diff -rq` limpio).

**Verificación**: se comparará el `.nupkg` producido por este PR contra el del run inmediatamente anterior sobre `main`. Si difieren más allá de la versión, este PR no se mergea.

## Por qué el manifiesto

Hasta ahora la URL de `vk.xml` solo la conocía el `CD.yml`, y como input de workflow — nada podía leerla sin parsear un YAML que no está pensado como fuente de datos. En la flota, **solo 2 de 13 repos** declaran su upstream en algún sitio legible por máquina; este es uno de los dos, y aun así no era consultable.

`binding.yml` recoge de dónde sale la spec, cómo se trae y qué escribe el generador. Es lo que permitirá que las herramientas vean el upstream.

## Rollback

`evergine-standards@v2` sigue intacto. Revertir este commit restaura el pipeline anterior exactamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)