### PR TITLE
feat: expose force-publish on manual CD runs

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      force-publish:
+        description: 'Publish even if the generated API did not change (for shipping a reviewed regeneration)'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '30 1 1 * *' # Monthly update on day 1 at 01:30
 
@@ -32,6 +37,7 @@ jobs:
       runtime-identifier: ""                       # Runtime identifier (win-x64, linux-x64, etc.)
       build-configuration: "Release"               # Build configuration (Release, Debug, etc.)
       revision: ${{ github.run_number }}           # Revision for date-based version (bindings style). Use with bindings.
+      force-publish: ${{ inputs.force-publish || false }}
       publish-enabled: ${{ !inputs.skip-assets-publishing }}
       enable-email-notifications: true
     secrets:


### PR DESCRIPTION
Conecta el input `force-publish` de `v1.4.0` para que sea usable desde `workflow_dispatch`.

Sin él, el trabajo que un agente regenera y un revisor mergea **nunca llega a nuget.org**: el PR commitea la salida regenerada, así que cuando el CD corre después regenera bytes idénticos, no ve cambio y se salta la publicación.

**La ruta programada no cambia.** El gate sigue impidiendo que una errata de Khronos produzca un bump de versión que no significa nada. Lo único nuevo es poder sacar a mano algo ya aprobado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)