### PR TITLE
feat: gate agent pull requests on the public API delta

### DIFF
--- a/.github/workflows/api-gate.yml
+++ b/.github/workflows/api-gate.yml
@@ -1,0 +1,22 @@
+# Measures what a pull request does to the public API surface, and merges the
+# binding updater's work when nothing anyone depends on has moved.
+#
+# The measurement runs on every pull request, including human ones -- knowing
+# which symbols a change adds or removes is useful whoever wrote it. Only the
+# merge is restricted to the agent.
+
+name: API Gate
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  api:
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-api-gate.yml@v1
+    with:
+      binding-project: "VulkanGen/Evergine.Bindings.Vulkan/Evergine.Bindings.Vulkan.csproj"
+      auto-merge: true
+      app-client-id: ${{ vars.APP_CLIENT_ID }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Wires up `binding-api-gate` from toolbox v1.8.0.

Measures every pull request; merges only the updater's, and only when the API is strictly additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)