### PR TITLE
test: exercise the API gate with a breaking change

### DIFF
--- a/VulkanGen/Evergine.Bindings.Vulkan/StdVideoH264Level.cs
+++ b/VulkanGen/Evergine.Bindings.Vulkan/StdVideoH264Level.cs
@@ -6,7 +6,7 @@ namespace Evergine.Bindings.Vulkan
 {
     public enum StdVideoH264Level
     {
-        STD_VIDEO_H264_LEVEL_1_0 = 0,
+        STD_VIDEO_H264_LEVEL_1_0_RENAMED = 0,
         STD_VIDEO_H264_LEVEL_1_1 = 1,
         STD_VIDEO_H264_LEVEL_1_2 = 2,
         STD_VIDEO_H264_LEVEL_1_3 = 3,


### PR DESCRIPTION
Throwaway. Renames one public enum member to confirm the gate reports `breaking` and withholds the merge. Will be closed once the verdict is in.